### PR TITLE
Fix for unafe and unsafe_auto_accept options

### DIFF
--- a/get_objects.py
+++ b/get_objects.py
@@ -931,9 +931,9 @@ def args_initializer(parser=None, param=None):
     parser.add_argument("-x", "--proxy", required=False, nargs=1, default=[os.getenv('MGMT_CLI_PROXY')],
                         help="Proxy settings.    {user:password@proxy.server:port}\nEnvironment variable: MGMT_CLI_PROXY")
     parser.add_argument("--unsafe", required=False, default=["false"], choices=["true", "false"],
-                        help="UNSAFE! Ignore certificate verification.    {true/false}\nDefault {false}")
+                        help="UNSAFE! Ignore certificate verification.    {true/false}\nDefault {false}", nargs=1)
     parser.add_argument("--unsafe-auto-accept", required=False, default=["false"], choices=["true", "false"],
-                        help="UNSAFE! Auto accept fingerprint during certificate verification.   {true/false}\nDefault {false}")
+                        help="UNSAFE! Auto accept fingerprint during certificate verification.   {true/false}\nDefault {false}", nargs=1)
     return parser.parse_args()
 
 


### PR DESCRIPTION
Right now the unsafe and unsafe_auto_accept options won't actually work. This is due to the checks done on line 61 and 62 in get_objects.py:
`unsafe = (args.unsafe[0] == "true")`
`unsafe_auto_accept = (args.unsafe_auto_accept[0] == "true")`

Since argparse misses `nargs=1` on both options, `--unsafe true` or `--unsafe-auto-accept true` will become `t` when the variable `unsafe` is set in `unsafe = (args.unsafe[0] == "true")`. Adding `nargs=1` fixes this so the arguments becomes a list instead of a string.

The checks should have been:
`unsafe = (args.unsafe == "true")`
`unsafe_auto_accept = (args.unsafe_auto_accept == "true")`
but to keep the consistency the fix got added to args_initializer instead.